### PR TITLE
update profile image refactor

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -61,7 +61,7 @@ export default function Navigation({ hasNewDm = false }) {
       </div>
 
       <div className={styles.profile} onClick={() => router.push(`/ProfilePage/${profileData.id}`)}>
-        <img src={`${profileData?.profile_image}`}
+        <img src={profileData?.profile_image || '/assets/ProfileImage.jpg'}
           alt="Profile"
           onError={(e) => {
             e.target.onerror = null;
@@ -94,7 +94,13 @@ export default function Navigation({ hasNewDm = false }) {
         </div>
 
         <div className={styles.modalProfile} onClick={() => router.push(`/ProfilePage/${profileData?.id}`)}>
-          <img src="/assets/test.png" alt="Profile" />
+          <img src={profileData?.profile_image || '/assets/ProfileImage.jpg'}
+            alt="Profile"
+            onError={(e) => {
+              e.target.onerror = null;
+              e.target.src = '/assets/ProfileImage.jpg';
+            }}
+          />
           <span className={styles.modalProfileName}>
             {profileData ? (
               <div>{profileData.full_name}</div>

--- a/src/pages/EditProfilePage/EditProfilePage.module.scss
+++ b/src/pages/EditProfilePage/EditProfilePage.module.scss
@@ -39,7 +39,14 @@
     border-radius: 50%;
     object-fit: cover;
     border: 2px solid #ddd;
+    cursor: pointer;
 }
+
+.profilePic:hover {
+    box-shadow: 0 0 0 4px #4d90fe33;
+    opacity: 0.8;
+    transition: box-shadow 0.2s, opacity 0.2s;
+  }  
 
 .inputs {
     display: flex;
@@ -74,7 +81,6 @@
     text-align: center;
     border: 1px solid #ddd;
     color: rgb(255, 196, 0);;
-    cursor: pointer;
 
     img {
         width: 100%;
@@ -84,10 +90,6 @@
 
 .clickableImage {
   cursor: pointer;
-  transition: opacity 0.2s;
-}
-.clickableImage:hover {
-  opacity: 0.8;
 }
 
 .saveButton {

--- a/src/pages/EditProfilePage/index.jsx
+++ b/src/pages/EditProfilePage/index.jsx
@@ -78,17 +78,32 @@ export default function EditProfilePage({ hasNewDm }) {
         }
       
         try {
-          const response = await fetch(`${BASE_URL}/user/${user.id}/`, {
+        //   const response = await fetch(`${BASE_URL}/user/${user.id}/`, {
+        //     method: "PATCH",
+        //     body: form,
+        //   });
+      
+        //   const data = await response.json();
+        //   if (!response.ok) throw new Error(data.message || "Update failed");
+
+            const response = await fetch(`${BASE_URL}/user/${user.id}/`, {
             method: "PATCH",
             body: form,
+            credentials: 'include', // If backend uses sessions/cookies
+            // headers: Do NOT set Content-Type when using FormData
           });
-      
-          const data = await response.json();
+          let data;
+          try {
+            data = await response.json();
+          } catch (e) {
+            const text = await response.text();
+            throw new Error("Non-JSON response: " + text);
+          }
           if (!response.ok) throw new Error(data.message || "Update failed");
-          console.log("Profile updated", data);
-        } catch (err) {
-          console.error("Failed to update profile:", err);
-        }
+           
+         } catch (err) {
+           console.error("Failed to update profile:", err);
+         }
       }       
 
     return (
@@ -102,13 +117,31 @@ export default function EditProfilePage({ hasNewDm }) {
                     </div>
                     <h1>Account Settings</h1>
                 </div>
-                <img className={styles.profilePic} src={`${profileData?.profile_image}`}
-                    alt="Profile Image"
-                    onError={(e) => {
-                        e.target.onerror = null;
-                        e.target.src = '/assets/ProfileImage.jpg';
-                    }}
-                />
+                <label className={styles.profilePic} 
+                        htmlFor="profileImageUpload">
+                    <img className={styles.profilePic} 
+                        src={
+                            formData.profile_image instanceof File
+                                ? URL.createObjectURL(formData.profile_image)
+                                : profileData?.profile_image 
+                                    ? profileData.profile_image
+                                    : '/assets/ProfileImage.jpg'
+                            }
+                        alt="Profile Image"
+                        title="Click to change"
+                        onError={(e) => {
+                            e.target.onerror = null;
+                            e.target.src = '/assets/ProfileImage.jpg';
+                        }}
+                    />
+                </label>
+                <input
+                    id="profileImageUpload"
+                    type="file"
+                    accept="image/*"
+                    style={{ display: 'none' }}
+                    onChange={(e) => setFormData({ ...formData, profile_image: e.target.files[0] })}
+                    />
                 <h3 className={styles.name}>{profileData?.full_name}</h3>
             </div>
 
@@ -169,37 +202,26 @@ export default function EditProfilePage({ hasNewDm }) {
                             value={formData.skills_interests}
                             onChange={(e) => setFormData({...formData, skills_interests: e.target.value})}
                         />
-                    <p>Profile Image</p>
-                    <label className={styles.profileImageInput} htmlFor="profileImageUpload">
-                    <img
-                        src={
-                        formData.profile_image instanceof File
-                            ? URL.createObjectURL(formData.profile_image)
-                            : `${profileData?.profile_image}`
-                        }
-                        alt="Profile Image"
-                        title="Click to change"
-                        className={styles.clickableImage}
-                    />
-                    </label>
-                    <input
-                    id="profileImageUpload"
-                    type="file"
-                    accept="image/*"
-                    style={{ display: 'none' }}
-                    onChange={(e) => setFormData({ ...formData, profile_image: e.target.files[0] })}
-                    />
 
                     <p>Profile Header</p>
                         <div className={styles.profileHeaderInput}>
-                            <img src="/assets/test.png" alt="Profile Header" />
-                        </div>
-                            <input
-                                type="file"
-                                accept="image/*"
-                                onChange={(e) => setFormData({ ...formData, profile_header: e.target.files[0] })}
-                                style={{ display: 'none' }}
+                            <img
+                                src={
+                                formData.profile_header instanceof File
+                                    ? URL.createObjectURL(formData.profile_header)
+                                    : profileData?.profile_header
+                                }
+                                alt="Profile Header"
+                                title="Click to change"
+                                className={styles.clickableImage}
                             />
+                        </div>
+                        <input
+                            type="file"
+                            accept="image/*"
+                            onChange={(e) => setFormData({ ...formData, profile_header: e.target.files[0] })}
+                            style={{ display: 'none' }}
+                        />
 
                     <button
                         className={styles.saveButton}

--- a/src/pages/EditProfilePage/index.jsx
+++ b/src/pages/EditProfilePage/index.jsx
@@ -78,33 +78,18 @@ export default function EditProfilePage({ hasNewDm }) {
         }
       
         try {
-        //   const response = await fetch(`${BASE_URL}/user/${user.id}/`, {
-        //     method: "PATCH",
-        //     body: form,
-        //   });
-      
-        //   const data = await response.json();
-        //   if (!response.ok) throw new Error(data.message || "Update failed");
-
-            const response = await fetch(`${BASE_URL}/user/${user.id}/`, {
+          const response = await fetch(`${BASE_URL}/user/${user.id}/`, {
             method: "PATCH",
             body: form,
-            credentials: 'include', // If backend uses sessions/cookies
-            // headers: Do NOT set Content-Type when using FormData
           });
-          let data;
-          try {
-            data = await response.json();
-          } catch (e) {
-            const text = await response.text();
-            throw new Error("Non-JSON response: " + text);
-          }
+      
+          const data = await response.json();
           if (!response.ok) throw new Error(data.message || "Update failed");
-           
-         } catch (err) {
-           console.error("Failed to update profile:", err);
-         }
-      }       
+          console.log("Profile updated", data);
+        } catch (err) {
+          console.error("Failed to update profile:", err);
+        }
+      }      
 
     return (
         <div className={styles.container}>

--- a/src/pages/ProfilePage/ProfilePage.module.scss
+++ b/src/pages/ProfilePage/ProfilePage.module.scss
@@ -105,7 +105,6 @@
 .editButton {
   background-color: #24873d;
   color: #fff;
-  &:hover { background-color: rgb(30, 100, 50); }
 }
 
 .signoutButton {

--- a/src/pages/ProfilePage/[id].jsx
+++ b/src/pages/ProfilePage/[id].jsx
@@ -55,7 +55,7 @@ export default function ProfilePage({ hasNewDm }) {
 
         <img
           className={styles.profilePic}
-          src={`${profileData.profile_image}`}
+          src={profileData.profile_image || '/assets/ProfileImage.jpg'}
           alt="Profile"
           onError={(e) => {
             e.target.onerror = null;


### PR DESCRIPTION
What was done:
- Removed large image box from the page.
- Added click handler to circular profile image to trigger upload (with some styling eg. hover).
- Updated styling/logic so the new image displays immediately.
- Verified that image saves, especially on refresh.

Changes were made to pages/EditProfilePage/index.js and pages/EditProfilePageEditProfilePage.module.css.

Requires backend change commit: [4c2c05399bfd5c6d6f2f8ded2c6366fdf61fe20c.](https://github.com/AtriaCoop/new-townhall-backend/commit/4c2c05399bfd5c6d6f2f8ded2c6366fdf61fe20c).

<img width="1768" height="501" alt="image" src="https://github.com/user-attachments/assets/dfc2d629-01b6-4636-b8d9-7ef67430ac39" />
<img width="1702" height="405" alt="image" src="https://github.com/user-attachments/assets/d763e0f4-8bd5-4302-9e1c-adc4b5b61d4a" />
<img width="1087" height="477" alt="image" src="https://github.com/user-attachments/assets/062f6ea4-1318-4ea2-a666-c7bd7ff81962" />
