### PR TITLE
Made the VFJC logo clickable and routed it to home page

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -45,7 +45,7 @@ export default function Navigation({ hasNewDm = false }) {
       <div className={styles.menu} onClick={toggleSidebar}><Menu /></div>
 
       {/* Desktop logo */}
-      <img src="/assets/VFJC.png" alt="VFJC Logo" className={styles.logo} />
+      <img src="/assets/VFJC.png" alt="VFJC Logo" className={styles.logo} onClick={() => router.push('/HomePage')} />
 
       {/* Tablet sidebar */}
       <img src="/assets/VFJCsm.png" alt="VFJC Sidebar Logo" className={styles.logoSmall} />
@@ -83,7 +83,7 @@ export default function Navigation({ hasNewDm = false }) {
         <div className={styles.closeIcon} onClick={() => setIsSidebarOpen(false)}>✕</div>
 
         <div className={styles.modalContent}>
-          <img src="/assets/VFJC.png" alt="VFJC Logo" className={styles.logo} />
+          <img src="/assets/VFJC.png" alt="VFJC Logo" className={styles.logo} onClick={() => router.push('/HomePage')} />
           <div className={styles.separator}></div>
 
           <div className={styles.logos}>

--- a/src/components/Navigation/Navigation.module.scss
+++ b/src/components/Navigation/Navigation.module.scss
@@ -28,6 +28,11 @@
     text-align: center;
     height: 40px;
     object-fit: contain;
+    cursor: pointer;
+  }
+
+  .logo:hover {
+    opacity: 0.7;
   }
 
   .logoSmall {


### PR DESCRIPTION
What was done:
The Vancouver Food Justice Coalition now becomes slightly transparent when you hover over it, and clicking it will route you to the home page. 

No hover:
<img width="354" height="131" alt="image" src="https://github.com/user-attachments/assets/a6540915-e0b0-4cd5-98e7-d2968e206984" />

Hover:
<img width="274" height="115" alt="image" src="https://github.com/user-attachments/assets/f290604a-fb9e-4feb-b2b7-e2806f0c1a54" />

After clicking it takes you back to homepage:
<img width="1874" height="293" alt="image" src="https://github.com/user-attachments/assets/96b326a9-65b5-4a62-95c5-c24d851d8621" />

