### PR TITLE
Prevent login attempt with empty fields

### DIFF
--- a/src/pages/LandingPage/index.jsx
+++ b/src/pages/LandingPage/index.jsx
@@ -58,8 +58,12 @@ export default function LandingPage() {
 
   const handleLogIn = async (event) => {
     event.preventDefault();
-    setLoading(true);
     const { email, password } = formData;
+    if(email == "" || password == "") {
+      setMessage("Please fill in all fields.");
+      return;
+    }
+    setLoading(true);
 
     try {
       const csrfRes = await fetch(`${BASE_URL}/auth/csrf/`, {


### PR DESCRIPTION
What was done: 
Prevents the user from being able to attempt a login when either the username of password fields are empty. 

New message displayed when invalid login was attempted:
<img width="529" height="476" alt="image" src="https://github.com/user-attachments/assets/3fc53436-c53e-4612-9e6c-934b1648791e" />


Old:
<img width="756" height="616" alt="image" src="https://github.com/user-attachments/assets/c1974457-ba6d-4cae-84af-1d7a442c7ddd" />
(You would get stuck in the loading screen)
