### PR TITLE
Sets loading to false when our POST request fails(through invalid username or password)

### DIFF
--- a/src/pages/LandingPage/index.jsx
+++ b/src/pages/LandingPage/index.jsx
@@ -99,6 +99,7 @@ export default function LandingPage() {
         localStorage.setItem("user", JSON.stringify(data.user));
         router.push("/HomePage");
       } else {
+        setLoading(false);
         setError(data.error || "Invalid email or password");
       }
     } catch (err) {


### PR DESCRIPTION
Previously: 
Entering an invalid username or password resulted in you getting stuck on the loading screen:
<img width="890" height="650" alt="image" src="https://github.com/user-attachments/assets/b522c641-bf77-4db5-80f5-dae07d5dfbc1" />



Now it handles invalid username or password:
<img width="572" height="505" alt="image" src="https://github.com/user-attachments/assets/944b7f89-8c87-4e00-b5e6-8bc2cd878b88" />

<img width="631" height="566" alt="image" src="https://github.com/user-attachments/assets/ffec14a0-6865-4502-b11c-5cdcf575863a" />
