### PR TITLE
AFR-52 Display error or success message after form submission

### DIFF
--- a/src/pages/EditProfilePage/EditProfilePage.module.scss
+++ b/src/pages/EditProfilePage/EditProfilePage.module.scss
@@ -33,6 +33,29 @@
   }
 }
 
+.toast {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1100;
+  padding: 12px 14px;
+  border-radius: 6px;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+}
+
+.toastSuccess {
+  background: #e7f7ec;
+  color: #1b5e20;
+  border: 1px solid #b5e1c1;
+}
+
+.toastError {
+  background: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c6cb;
+}
+
 .profilePic {
     width: 149px;
     height: 149px;
@@ -74,6 +97,8 @@
         background-color: rgb(255, 255, 255);
     }
 }
+
+// Removed old in-form alert styles in favor of floating toast
 
 .profileImageInput,
 .profileHeaderInput {

--- a/src/pages/ProfilePage/ProfilePage.module.scss
+++ b/src/pages/ProfilePage/ProfilePage.module.scss
@@ -18,6 +18,29 @@
   gap: 1rem;
 }
 
+.toast {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1200;
+  padding: 12px 14px;
+  border-radius: 6px;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+}
+
+.toastSuccess {
+  background: #e7f7ec;
+  color: #1b5e20;
+  border: 1px solid #b5e1c1;
+}
+
+.toastError {
+  background: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c6cb;
+}
+
 .cardHeader {
   font-size: 1rem;
   font-weight: 700;


### PR DESCRIPTION
Before:
- No feedback to users upon clicking Save in the Edit Profile page.

After:
- Now a toast message will be displayed based on the backend response, after navigation.

Success:
<img width="1603" height="324" alt="toast success" src="https://github.com/user-attachments/assets/318c241f-ee56-4880-b4dd-e46ad02f62a9" />

Failure:
<img width="1469" height="265" alt="image" src="https://github.com/user-attachments/assets/4a89c6be-9a13-40ab-8be4-71adb981dead" />

To replicate the failure mode, turn off the backend server and try to save from the Edit Profile page.
