### PR TITLE
AFR-55 Add email format validation in registerUser

### DIFF
--- a/src/utils/authHelpers.jsx
+++ b/src/utils/authHelpers.jsx
@@ -12,6 +12,14 @@ export function getCookie(name) {
     return null;
   }
 
+export function validateEmail(email) {
+  const trimmedEmail = email.trim().toLowerCase();
+  const emailRegex = /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?)*$/i;
+  const isValid = emailRegex.test(trimmedEmail);
+  
+  return isValid;
+}
+
 
 export async function fetchCsrfToken() {
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/csrf/`, {
@@ -24,6 +32,10 @@ export async function fetchCsrfToken() {
 
 export const registerUser = async (formData) => {
   try {
+    if (!validateEmail(formData.email)) {
+      return { error: "Please enter a valid email address." };
+    }
+
     const csrfToken = getCookie("csrftoken");
     console.log("CSRF Token being sent:", csrfToken);
 


### PR DESCRIPTION
## Summary
Client now validates emails during registration using RegEx so that backend is not hit with invalid emails:

## Related Issues:
Fixes https://atriadev.atlassian.net/browse/AFR-55

## Checklist
- validateEmail function in authHelpers contains the RegEx logic.
- RegEx rules were obtained from: [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/email).
- registerUser will check if email is validated, if not, break out before sending backend request.
- Users are given feedback of invalid input.

## How to Test
- Attempt registration with `user@` → should show invalid email error.
- Attempt registration with `user@example.com` → should proceed normally.

## Screenshot
<img width="600" height="545" alt="image" src="https://github.com/user-attachments/assets/9b3ef0ed-0d9e-4037-8f1a-31ec271930e8" />

