### PR TITLE
KAN 10 Loading spinner on posts load

### DIFF
--- a/src/pages/HomePage/HomePage.module.scss
+++ b/src/pages/HomePage/HomePage.module.scss
@@ -53,4 +53,15 @@
     background: none;
     margin-left: -1rem;
   }
-  
+
+.emptyFeed {
+  text-align: center;
+  color: #777;
+  padding: 40px 0;
+  font-size: 1.1rem;
+}
+
+.newsfeedLoader {
+    transform: scale(0.8);
+    transform-origin: center;
+}  

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -2,6 +2,7 @@ import Navigation from '@/components/Navigation/Navigation'
 import styles from '@/pages/HomePage/HomePage.module.scss'
 import Post from '@/components/Post/Post';
 import PostModal from '@/components/PostModal/PostModal';
+import Loader from '@/components/Loader/Loader';
 import { useEffect, useRef, useState } from 'react';
 import { formatDistance } from 'date-fns';
 
@@ -9,6 +10,7 @@ export default function HomePage({ hasNewDm }) {
     const BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '';
 
     const [showModal, setShowModal] = useState(false);
+    const [loading, setLoading] = useState(true);
     const [posts, setPosts] = useState([]);
     const [profileData, setProfileData] = useState(null)
 
@@ -46,6 +48,7 @@ export default function HomePage({ hasNewDm }) {
       useEffect(() => {
         async function fetchPosts() {
           try {
+            setLoading(true);
             const res = await fetch(`${BASE_URL}/post/`);
             const data = await res.json();
 
@@ -75,10 +78,12 @@ export default function HomePage({ hasNewDm }) {
               comments: p.comments,
             }))
             .reverse();
-
+            
             setPosts(formattedPosts);
+            setLoading(false);
           } catch (err) {
             console.error("Failed to fetch posts", err);
+            setLoading(false);
           }
         }
       
@@ -109,6 +114,8 @@ export default function HomePage({ hasNewDm }) {
                 </div>
 
                 {/* Post component */}
+                {loading ? <div className={styles.newsfeedLoader}><Loader/></div> : null}
+                {!loading && posts.length < 1 ? <div className={styles.emptyFeed}><i>Your feed is empty</i></div> : null}
                 {posts.map((post) => (
                     <Post 
                         key={post.id}


### PR DESCRIPTION
## Jira Ticket Link
https://anselatria2.atlassian.net/browse/KAN-10
## Summary
<img width="902" height="418" alt="Screenshot from 2025-10-07 16-33-30" src="https://github.com/user-attachments/assets/9c8e177a-35da-4625-ba9d-df871c367fe3" />
Added a spinning loader (reused from the login page) to the homepage news feed. Renders conditionally when awaiting fetch of posts data. Also added an alternate message to display if loading is finished but there are no posts in the user's feed.