### PR TITLE
Tagify skills & interests field in Profile page

### DIFF
--- a/src/components/TagifyInput/TagifyInput.jsx
+++ b/src/components/TagifyInput/TagifyInput.jsx
@@ -113,6 +113,13 @@ export default function TagifyInput({
     }
   }
 
+  function handleBlur() {
+    if (disabled) return;
+    // Only Enter commits a tag; abandon draft text when focus leaves.
+    setInputValue("");
+    setLocalError("");
+  }
+
   function handleInputChange(e) {
     if (disabled) return;
     setInputValue(e.target.value);
@@ -153,6 +160,7 @@ export default function TagifyInput({
                 disabled={disabled}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
                 autoComplete="off"
                 maxLength={maxTagLength}
               />

--- a/src/components/TagifyInput/TagifyInput.jsx
+++ b/src/components/TagifyInput/TagifyInput.jsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useState } from "react";
+import Tag from "@/components/Tag/Tag";
+import formInputStyles from "@/components/FormInputText/FormInputText.module.scss";
+import styles from "./TagifyInput.module.scss";
+
+function normalizeTagName(input) {
+  if (typeof input !== "string") return "";
+  return input
+    .trim()
+    // allow users to paste “#tag”
+    .replace(/^#\s*/, "")
+    // collapse internal whitespace for stable length/dup checking
+    .replace(/\s+/g, " ");
+}
+
+export function parseTagString(value) {
+  if (!value || typeof value !== "string") return [];
+
+  // Accept common separators (commas/newlines/semicolons)
+  return value
+    .replace(/\r\n/g, "\n")
+    .replace(/[;\n]+/g, ",")
+    .split(",")
+    .map(normalizeTagName)
+    .filter(Boolean);
+}
+
+function joinTags(tags) {
+  return tags.join(", ");
+}
+
+export default function TagifyInput({
+  label,
+  placeholder,
+  value,
+  onChange,
+  isRequired,
+  disabled,
+  minTagLength = 2,
+  maxTagLength = 40,
+  maxTags = 10,
+}) {
+  const parsedFromValue = useMemo(() => parseTagString(value), [value]);
+  const [tags, setTags] = useState(parsedFromValue);
+  const [inputValue, setInputValue] = useState("");
+  const [localError, setLocalError] = useState("");
+
+  useEffect(() => {
+    setTags(parsedFromValue);
+  }, [parsedFromValue]);
+
+  function notifyChange(nextTags) {
+    setTags(nextTags);
+    onChange?.(joinTags(nextTags));
+  }
+
+  function addRawCandidates(raw) {
+    const candidates = raw
+      .split(/[;,]+/g)
+      .map(normalizeTagName)
+      .filter(Boolean);
+
+    if (candidates.length === 0) return;
+
+    if (tags.length >= maxTags) {
+      setLocalError(`Max ${maxTags} tags allowed.`);
+      return;
+    }
+
+    const nextTags = [...tags];
+
+    for (const candidate of candidates) {
+      if (nextTags.length >= maxTags) {
+        setLocalError(`Max ${maxTags} tags allowed.`);
+        break;
+      }
+
+      if (candidate.length < minTagLength) {
+        setLocalError(`Tags must be at least ${minTagLength} characters.`);
+        return;
+      }
+      if (candidate.length > maxTagLength) {
+        setLocalError(`Tags must be ${maxTagLength} characters or less.`);
+        return;
+      }
+
+      const alreadyExists = nextTags.some(
+        (t) => t.toLowerCase() === candidate.toLowerCase()
+      );
+      if (alreadyExists) continue;
+
+      nextTags.push(candidate);
+    }
+
+    setLocalError("");
+    notifyChange(nextTags);
+    setInputValue("");
+  }
+
+  function removeTag(idx) {
+    const nextTags = tags.filter((_, i) => i !== idx);
+    setLocalError("");
+    notifyChange(nextTags);
+  }
+
+  function handleKeyDown(e) {
+    if (disabled) return;
+
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (!inputValue.trim()) return;
+      addRawCandidates(inputValue);
+    }
+  }
+
+  function handleInputChange(e) {
+    if (disabled) return;
+    setInputValue(e.target.value);
+    if (localError) setLocalError("");
+  }
+
+  const canAddMore = tags.length < maxTags;
+
+  return (
+    <div className={formInputStyles.formGroup}>
+      {label && (
+        <label className={formInputStyles.inputLabel}>
+          {label}
+          {isRequired && (
+            <span className={formInputStyles.required}>*</span>
+          )}
+        </label>
+      )}
+
+      <div className={styles.wrapper} aria-disabled={disabled ? "true" : "false"}>
+        <div className={styles.row}>
+          {tags.map((t, idx) => (
+            <Tag
+              key={`${t}-${idx}`}
+              name={t}
+              removable
+              onRemove={() => removeTag(idx)}
+            />
+          ))}
+
+          {canAddMore && (
+            <div className={styles.inlineInputWrapper}>
+              <span className={styles.inputHash}>#</span>
+              <input
+                className={styles.inlineInput}
+                placeholder={placeholder}
+                value={inputValue}
+                disabled={disabled}
+                onChange={handleInputChange}
+                onKeyDown={handleKeyDown}
+                autoComplete="off"
+                maxLength={maxTagLength}
+              />
+            </div>
+          )}
+        </div>
+
+        {localError && (
+          <span className={formInputStyles.errorMessage} role="alert">
+            {localError}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/TagifyInput/TagifyInput.module.scss
+++ b/src/components/TagifyInput/TagifyInput.module.scss
@@ -1,0 +1,64 @@
+@use '@/styles/variables' as *;
+@use '@/styles/mixins' as *;
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+  min-height: 28px;
+}
+
+.inlineInputWrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-1;
+  padding: 3px $spacing-2;
+  border-radius: $radius-full;
+  border: 1px solid var(--primary);
+  background: var(--input-bg);
+  box-shadow: 0 0 0 3px rgba($primary-500, 0.1);
+  min-width: 180px;
+  max-width: 260px;
+}
+
+.inputHash {
+  color: var(--primary);
+  font-size: $font-size-xs;
+  font-weight: $font-weight-semibold;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.inlineInput {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: $font-family-body;
+  font-size: $font-size-xs;
+  min-width: 60px;
+  padding: 0;
+  line-height: 1.4;
+
+  &::placeholder {
+    color: var(--text-muted);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+

--- a/src/pages/EditProfilePage/index.jsx
+++ b/src/pages/EditProfilePage/index.jsx
@@ -6,6 +6,7 @@ import { BASE_URL } from "@/constants/api";
 import Icon from "@/icons/Icon";
 import { validateUrl } from "@/utils/validateUrl";
 import FormInputText from "@/components/FormInputText/FormInputText";
+import TagifyInput from "@/components/TagifyInput/TagifyInput";
 import styles from "./EditProfilePage.module.scss";
 
 export default function EditProfilePage() {
@@ -363,12 +364,11 @@ export default function EditProfilePage() {
               value={formData.about_me}
               onChange={handleInputChange}
             />
-            <FormInputText
-              name="skills_interests"
+            <TagifyInput
               label="Skills & Interests"
-              placeholder="Skills and interests that benefit the coalition"
+              placeholder="Add a skill and press Enter..."
               value={formData.skills_interests}
-              onChange={handleInputChange}
+              onChange={(next) => handleFieldChange({ skills_interests: next })}
             />
           </div>
         </div>

--- a/src/pages/ProfilePage/ProfilePage.module.scss
+++ b/src/pages/ProfilePage/ProfilePage.module.scss
@@ -336,6 +336,12 @@
   line-height: $line-height-relaxed;
 }
 
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+}
+
 // Image Modal
 .imageModalOverlay {
   position: fixed;

--- a/src/pages/ProfilePage/[id].jsx
+++ b/src/pages/ProfilePage/[id].jsx
@@ -3,6 +3,8 @@ import { useState, useEffect, useRef } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { authenticatedFetch } from "@/utils/authHelpers";
 import SocialLinks from "@/components/SocialLinks/SocialLinks";
+import Tag from "@/components/Tag/Tag";
+import { parseTagString } from "@/components/TagifyInput/TagifyInput";
 import styles from "./ProfilePage.module.scss";
 
 export default function ProfilePage() {
@@ -58,6 +60,8 @@ export default function ProfilePage() {
   }, [toast]);
 
   if (!profileData) return null;
+
+  const skillsInterestsTags = parseTagString(profileData.skills_interests);
 
   return (
     <div className={styles.profilePage}>
@@ -228,7 +232,15 @@ export default function ProfilePage() {
           {profileData.skills_interests && (
             <div className={styles.detailSection}>
               <h3 className={styles.detailLabel}>Skills & Interests</h3>
-              <p className={styles.detailContent}>{profileData.skills_interests}</p>
+              {skillsInterestsTags.length > 0 ? (
+                <div className={styles.tagList} aria-label="Skills and interests">
+                  {skillsInterestsTags.map((t, idx) => (
+                    <Tag key={`${t}-${idx}`} name={t} removable={false} />
+                  ))}
+                </div>
+              ) : (
+                <p className={styles.detailContent}>{profileData.skills_interests}</p>
+              )}
             </div>
           )}
 

--- a/src/pages/SetUpPage/index.jsx
+++ b/src/pages/SetUpPage/index.jsx
@@ -5,6 +5,7 @@ import { authenticatedFetch } from "@/utils/authHelpers";
 import { getStoredUser } from "@/utils/getStoredUser";
 import { BASE_URL } from "@/constants/api";
 import FormInputText from "@/components/FormInputText/FormInputText";
+import TagifyInput from "@/components/TagifyInput/TagifyInput";
 import { validateUrl } from "@/utils/validateUrl";
 
 const INITIAL_FORM_DATA = {
@@ -300,12 +301,13 @@ export default function SetUpPage() {
                 />
               </div>
               <div className={`${styles.formField} ${styles.fullWidth}`}>
-                <FormInputText
-                  name="skills_interests"
+                <TagifyInput
                   label="Skills & Interests"
-                  placeholder="How would you like to contribute to the coalition?"
+                  placeholder="Add a skill and press Enter..."
                   value={formData.skills_interests}
-                  onChange={handleInputChange}
+                  onChange={(next) =>
+                    setFormData((prev) => ({ ...prev, skills_interests: next }))
+                  }
                 />
               </div>
             </div>


### PR DESCRIPTION
feat(NT-123): implement tag-based skills and interests input

## Description
This PR introduces a tag-based input system for the **Skills & Interests** section on the profile edit page, improving usability and aligning with patterns similar to LinkedIn.

Instead of entering a single free-form string, users can now add skills and interests as individual tags for better structure and readability.

This update also improves input behavior by ensuring tags are only saved when explicitly confirmed via the `Enter` key.

## Changes
- Replace free-form input with a tag-based input component
- Create tags when the user presses `Enter`
- Display tags visually in the UI
- Allow users to remove tags via the ❌ button
- Ensure tags are persisted and correctly rendered on the user profile
- Prevent incomplete input from being saved when the user clicks away without pressing `Enter`
- Silently discard unconfirmed input values on blur

## Impact
- Improves user experience and input clarity
- Provides structured data for skills and interests
- Enhances consistency with modern UI patterns
- Prevents accidental or partial tag submissions

## Demo
https://github.com/user-attachments/assets/38d4b6e6-920a-4b70-963e-9baa188758ba

