### PR TITLE
Afr 169 create and fetch group chats

### DIFF
--- a/src/components/CreateGroupChatModal/CreateGroupChatModal.jsx
+++ b/src/components/CreateGroupChatModal/CreateGroupChatModal.jsx
@@ -66,7 +66,7 @@ export default function Modal({
 
         <button 
           className={styles.createGroupButton} 
-          onClick={onCreateGroup}
+          onClick={() => onCreateGroup(groupName, selectedUsers)}
           disabled={selectedUsers.length === 0 || !groupName}
         >
           Create Group

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -78,6 +78,8 @@ export default function Header() {
       console.error("Logout error:", error);
     }
     localStorage.removeItem("user");
+    localStorage.removeItem("joinedGroups");
+    localStorage.removeItem("activeGroup");
     router.push('/LandingPage');
   };
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -78,6 +78,7 @@ export default function Header() {
       console.error("Logout error:", error);
     }
     localStorage.removeItem("user");
+    // Remove joined groups and active group as a temporary fix until backend handles fetching group chats per user
     localStorage.removeItem("joinedGroups");
     localStorage.removeItem("activeGroup");
     router.push('/LandingPage');

--- a/src/components/JoinGroupModal/JoinGroupModal.jsx
+++ b/src/components/JoinGroupModal/JoinGroupModal.jsx
@@ -2,24 +2,43 @@ import styles from './JoinGroupModal.module.scss';
 import { useState } from 'react';
 import Icon from '@/icons/Icon';
 import { formatGroupName } from '@/utils/formatGroupName';
+import { authenticatedFetch } from '@/utils/authHelpers';
+import { BASE_URL } from '@/constants/api';
+import { useEffect } from 'react';
 
 export default function JoinGroupModal({ title, onClose, onJoinGroup, onCreatingAGroup }) {
   const [searchText, setSearchText] = useState('');
-
-  const groups = [
-    { name: "atria-questions-and-support" },
-    { name: "city-food-budget-city-meeting" },
-    { name: "living-wage-community-food-sector-analysis" },
-    { name: "wg-climate-resilient-local-food-systems" },
-    { name: "wg-decolonization-and-indigenous-food-sovereignty" },
-    { name: "wg-food-as-a-human-right" },
-    { name: "wg-food-justice-as-a-public-health-priority" },
-    { name: "wg-sustainable-resourcing-for-community-food-systems" },
-  ];
+  const [groups, setGroups] = useState([
+    { id: -1, name: "atria-questions-and-support" },
+    { id: -2, name: "city-food-budget-city-meeting" },
+    { id: -3, name: "living-wage-community-food-sector-analysis" },
+    { id: -4, name: "wg-climate-resilient-local-food-systems" },
+    { id: -5, name: "wg-decolonization-and-indigenous-food-sovereignty" },
+    { id: -6, name: "wg-food-as-a-human-right" },
+    { id: -7, name: "wg-food-justice-as-a-public-health-priority" },
+    { id: -8, name: "wg-sustainable-resourcing-for-community-food-systems" },
+  ]);
 
   const filteredGroups = groups.filter(group =>
     formatGroupName(group.name).toLowerCase().includes(searchText.toLowerCase())
   );
+
+  useEffect(() => {
+    const fetchGroups = async () => {
+      const userData = JSON.parse(localStorage.getItem("user") || "{}");
+      const userId = Number(userData.id);
+      const res = await authenticatedFetch(
+        `${BASE_URL}/chats/?user_id=${userId}`,
+        { credentials: "include" }
+      );
+      const data = await res.json();
+      const chatsFromServer = data?.data || [];
+
+      const customGroups = chatsFromServer.flatMap((c) => (c.is_group ? [{ id: c.id, name: c.name }] : []));
+      setGroups(prev => [...prev, ...customGroups]);
+    }
+    fetchGroups();
+  }, [BASE_URL]);
 
   return (
     <div className={styles.modalOverlay} onClick={onClose}>

--- a/src/components/JoinGroupModal/JoinGroupModal.jsx
+++ b/src/components/JoinGroupModal/JoinGroupModal.jsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 
 export default function JoinGroupModal({ title, onClose, onJoinGroup, onCreatingAGroup }) {
   const [searchText, setSearchText] = useState('');
-  const [groups, setGroups] = useState([
+  const [groups, setGroups] = useState([  // negative IDs to avoid conflicts with user group chat IDs
     { id: -1, name: "atria-questions-and-support" },
     { id: -2, name: "city-food-budget-city-meeting" },
     { id: -3, name: "living-wage-community-food-sector-analysis" },
@@ -24,6 +24,7 @@ export default function JoinGroupModal({ title, onClose, onJoinGroup, onCreating
   );
 
   useEffect(() => {
+    // Add user's group chats to list of default groups
     const fetchGroups = async () => {
       const userData = JSON.parse(localStorage.getItem("user") || "{}");
       const userId = Number(userData.id);

--- a/src/pages/GroupChatsPage/index.jsx
+++ b/src/pages/GroupChatsPage/index.jsx
@@ -273,6 +273,7 @@ export default function GroupChatsPage() {
         body: JSON.stringify({
           name: `${groupName}`,
           participants: [currentUserId, ...selectedUsers.map((user) => user.id)],
+          is_group: true,
         }),
       });
 

--- a/src/pages/GroupChatsPage/index.jsx
+++ b/src/pages/GroupChatsPage/index.jsx
@@ -265,6 +265,28 @@ export default function GroupChatsPage() {
     setActiveGroup("");
   };
 
+  const handleCreateGroup = async (groupName, selectedUsers) => {
+    try {
+      const res = await authenticatedFetch(`${BASE_URL}/chats/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: `${groupName}`,
+          participants: [currentUserId, ...selectedUsers.map((user) => user.id)],
+        }),
+      });
+
+      const data = await res.json();
+      const chatData = data?.data;
+      if (!chatData?.id) return;
+      
+      handleJoinGroup(groupName);
+      setShowCreateGroupModal(false);
+    } catch (err) {
+      console.error("Failed to create chat:", err);
+    }
+  }
+
   return (
     <div className={styles.container}>
       {/* Group Chats Sidebar */}
@@ -440,7 +462,7 @@ export default function GroupChatsPage() {
       {showCreateGroupModal && (
         <CreateGroupChatModal
           onClose={() => setShowCreateGroupModal(false)}
-          onCreateGroup={() => {return null;}}
+          onCreateGroup={handleCreateGroup}
           currUserId={currentUserId}
           title="New Group Chat"
         />


### PR DESCRIPTION
This PR is for feat(AFR-179). I added functionality to the group chat modal created in [AFR-169-allow-creating-group-chat ](https://github.com/AtriaCoop/townhallfrontend/tree/AFR-169-allow-creating-group-chat).

This should be merged after https://github.com/AtriaCoop/new-townhall-backend/pull/85 is approved and merged. 

On Open:
<img width="402" height="422" alt="Screenshot 2026-05-24 at 12 14 30 PM" src="https://github.com/user-attachments/assets/f1fbb1f8-4328-4571-9835-697b20b53260" />

Searching for Users:
<img width="408" height="335" alt="Screenshot 2026-05-24 at 12 14 24 PM" src="https://github.com/user-attachments/assets/f7e78479-4d83-40bf-b898-923df811ab87" />

Selecting Users:
- note: 'Create Group' button is disabled until participant(s) are selected and a group name is entered.
<img width="399" height="433" alt="Screenshot 2026-05-24 at 12 14 47 PM" src="https://github.com/user-attachments/assets/627a8d71-508b-4a5e-9731-cd88a89be89d" />

Group Chat example with 3 members:
<img width="1409" height="336" alt="Screenshot 2026-05-24 at 12 16 27 PM" src="https://github.com/user-attachments/assets/ae6c6633-a0b5-46ea-9d00-ccd4309d649f" />
