### PR TITLE
feat: added reaction option for messages

### DIFF
--- a/src/components/ChatWindow/ChatWindow.jsx
+++ b/src/components/ChatWindow/ChatWindow.jsx
@@ -7,6 +7,8 @@ import { BASE_URL } from '@/constants/api';
 import MessageModal from '@/components/MessageModal/MessageModal';
 import UpdateMessageModal from '../UpdateMessageModal/UpdateMessageModal';
 import MessageInput from '@/components/MessageInput/MessageInput';
+import ReactionPicker from '@/components/ReactionPicker/ReactionPicker';
+import { getReactionEmoji } from '@/constants/reactions';
 import { formatRelativeTime, formatExactTime } from '@/utils/formateDatetime';
 import useNotificationStore from '@/stores/notificationStore';
 
@@ -36,6 +38,7 @@ export default function ChatWindow({ chat, onClose }) {
     const [showMessageModal, setShowMessageModal] = useState(false);
     const [showUpdateMessageModal, setShowUpdateMessageModal] = useState(false);
     const [selectedMessage, setSelectedMessage] = useState(null);
+    const [activeReactionPickerId, setActiveReactionPickerId] = useState(null);
 
     const handleMessageClick = (msg) => {
       setShowMessageModal(true);
@@ -98,6 +101,7 @@ export default function ChatWindow({ chat, onClose }) {
               sender: Number(m.user?.id),
               id: m.id,
               timestamp: m.sent_at,
+              reactions: m.reactions || {},
             }));
 
             setMessages(formatted);
@@ -237,41 +241,103 @@ export default function ChatWindow({ chat, onClose }) {
             </div>
 
             <div className={styles.messages} ref={messagesContainerRef}>
-              {messages.map((msg, idx) => (
-                <div
-                  key={msg.id || idx}
-                  className={
-                    Number(msg.sender) === currentUserId
-                      ? styles.messageOutgoing
-                      : styles.messageIncoming
-                  }
-                >
-                  <div className={styles.messageContent}>
-                    {msg.text.startsWith("<img") ? (
-                      <div dangerouslySetInnerHTML={{ __html: msg.text }} />
-                    ) : (
-                      formatMessageWithLinks(msg.text)
+              {messages.map((msg, idx) => {
+                const isOwnMessage = Number(msg.sender) === currentUserId;
+                const showReactionPicker = activeReactionPickerId === msg.id;
+
+                return (
+                  <div
+                    key={msg.id || idx}
+                    className={[
+                      isOwnMessage ? styles.messageOutgoing : styles.messageIncoming,
+                      showReactionPicker ? styles.messageActionsPinned : '',
+                    ].join(' ')}
+                  >
+                    <div className={styles.messageContent}>
+                      {msg.text.startsWith("<img") ? (
+                        <div dangerouslySetInnerHTML={{ __html: msg.text }} />
+                      ) : (
+                        formatMessageWithLinks(msg.text)
+                      )}
+                    </div>
+
+                    {Object.keys(msg.reactions || {}).length > 0 && (
+                      <div className={styles.reactionsDisplay}>
+                        {Object.entries(msg.reactions).map(
+                          ([reactionType, users]) =>
+                            users.length > 0 && (
+                              <div key={reactionType} className={styles.reactionGroup}>
+                                <span className={styles.reactionEmoji}>
+                                  {getReactionEmoji(reactionType)}
+                                </span>
+                                <span className={styles.reactionCount}>{users.length}</span>
+                              </div>
+                            )
+                        )}
+                      </div>
                     )}
 
-                    {Number(msg.sender) === currentUserId && (
-                      <button
-                        className={styles.optionsButton}
-                        onClick={() => handleMessageClick(msg)}
+                    <div
+                      className={[
+                        styles.messageHoverActions,
+                        showReactionPicker ? styles.messageHoverActionsVisible : '',
+                      ].join(' ')}
+                    >
+                      <div className={styles.reactionWrapper}>
+                        <button
+                          type="button"
+                          className={`${styles.hoverActionButton} ${showReactionPicker ? styles.active : ''}`}
+                          onClick={() =>
+                            setActiveReactionPickerId((prev) =>
+                              prev === msg.id ? null : msg.id
+                            )
+                          }
+                          onMouseDown={(e) => e.stopPropagation()}
+                          title="Add reaction"
+                          aria-label="Add reaction"
+                        >
+                          <Icon name="smile" size={16} />
+                        </button>
+                        {showReactionPicker && (
+                          <ReactionPicker
+                            currentReactions={msg.reactions || {}}
+                            currentUserId={currentUserId}
+                            messageId={msg.id}
+                            BASE_URL={BASE_URL}
+                            setMessages={setMessages}
+                            onClose={() => setActiveReactionPickerId(null)}
+                            align={isOwnMessage ? 'end' : 'start'}
+                          />
+                        )}
+                      </div>
+
+                      {isOwnMessage && (
+                        <button
+                          type="button"
+                          className={styles.hoverActionButton}
+                          onClick={() => {
+                            setActiveReactionPickerId(null);
+                            handleMessageClick(msg);
+                          }}
+                          title="Message options"
+                          aria-label="Message options"
+                        >
+                          <Icon name="more" size={16} />
+                        </button>
+                      )}
+                    </div>
+
+                    {msg.timestamp && (
+                      <span
+                        className={styles.messageTimestamp}
+                        title={formatExactTime(msg.timestamp)}
                       >
-                        &#x22EF;
-                      </button>
+                        {formatRelativeTime(msg.timestamp)}
+                      </span>
                     )}
                   </div>
-                  {msg.timestamp && (
-                    <span
-                      className={styles.messageTimestamp}
-                      title={formatExactTime(msg.timestamp)}
-                    >
-                      {formatRelativeTime(msg.timestamp)}
-                    </span>
-                  )}
-                </div>
-              ))}
+                );
+              })}
             </div>
 
             {showMessageModal && (

--- a/src/components/ChatWindow/ChatWindow.module.scss
+++ b/src/components/ChatWindow/ChatWindow.module.scss
@@ -116,7 +116,8 @@
     width: fit-content;
     max-width: 80%;
     padding: $spacing-3 $spacing-4;
-    margin-bottom: 2px;
+    padding-bottom: $spacing-4;
+    margin-bottom: $spacing-2;
     position: relative;
     border-radius: $radius-lg;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
@@ -158,32 +159,99 @@
   gap: $spacing-1;
 }
 
-.optionsButton {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  font-size: $font-size-lg;
-  padding: 2px $spacing-1;
-  color: inherit;
-  flex-shrink: 0;
-  transition: opacity $transition-fast;
-  line-height: 1;
+.messageHoverActions {
+  position: absolute;
+  bottom: 0;
+  right: -6px;
+  transform: translateY(50%);
+  display: flex;
+  align-items: center;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-default);
+  border-radius: $radius-md;
+  box-shadow: var(--shadow-sm);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity $transition-fast, visibility $transition-fast;
+  z-index: $z-popover;
+  overflow: visible;
 
-  // Always show on touch devices (no hover)
-  opacity: 0.5;
-
-  @include md {
-    opacity: 0;
+  @include below-md {
+    opacity: 1;
+    visibility: visible;
   }
 }
 
-.messageIncoming:hover .optionsButton,
-.messageOutgoing:hover .optionsButton {
-  opacity: 0.6;
+.messageIncoming:hover .messageHoverActions,
+.messageOutgoing:hover .messageHoverActions,
+.messageHoverActionsVisible,
+.messageActionsPinned .messageHoverActions {
+  opacity: 1;
+  visibility: visible;
 }
 
-.optionsButton:hover {
-  opacity: 1 !important;
+.hoverActionButton {
+  @include flex-center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--icon-default);
+  border-radius: $radius-sm;
+  @include transition-all;
+
+  &:hover {
+    background-color: var(--bg-hover);
+    color: var(--icon-hover);
+  }
+
+  &.active {
+    background-color: var(--primary-subtle);
+    color: var(--primary);
+  }
+}
+
+.reactionWrapper {
+  position: relative;
+}
+
+.reactionsDisplay {
+  @include flex-start;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: $spacing-1;
+}
+
+.reactionGroup {
+  @include flex-center;
+  gap: 3px;
+  padding: 2px 8px;
+  background-color: rgba($white, 0.2);
+  border: 1px solid rgba($white, 0.25);
+  border-radius: $radius-full;
+  font-size: $font-size-xs;
+}
+
+.messageIncoming .reactionGroup {
+  background-color: var(--bg-secondary);
+  border-color: var(--border-default);
+}
+
+.reactionEmoji {
+  font-size: $font-size-sm;
+  line-height: 1;
+}
+
+.reactionCount {
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-xs;
+  opacity: 0.85;
+}
+
+.messageIncoming .reactionCount {
+  color: var(--text-secondary);
 }
 
 .messageTimestamp {

--- a/src/components/ReactionPicker/ReactionPicker.jsx
+++ b/src/components/ReactionPicker/ReactionPicker.jsx
@@ -8,9 +8,12 @@ export default function ReactionPicker({
   currentReactions = {},
   currentUserId,
   postId,
+  messageId,
   BASE_URL,
   setPosts,
+  setMessages,
   onClose,
+  align = 'center',
 }) {
   const pickerRef = useRef(null);
 
@@ -27,7 +30,9 @@ export default function ReactionPicker({
 
   async function handleReactionClick(reactionType) {
     try {
-      const url = `${BASE_URL}/post/${postId}/reaction/`;
+      const url = messageId
+        ? `${BASE_URL}/chats/messages/${messageId}/reaction/`
+        : `${BASE_URL}/post/${postId}/reaction/`;
       const response = await authenticatedFetch(url, {
         method: "PATCH",
         headers: {
@@ -44,11 +49,21 @@ export default function ReactionPicker({
 
       const result = await response.json();
 
-      setPosts(prevPosts =>
-        prevPosts.map(post =>
-          post.id === postId ? { ...post, reactions: result.reactions } : post
-        )
-      );
+      if (setMessages && messageId) {
+        setMessages((prevMessages) =>
+          prevMessages.map((message) =>
+            message.id === messageId
+              ? { ...message, reactions: result.reactions }
+              : message
+          )
+        );
+      } else if (setPosts && postId) {
+        setPosts((prevPosts) =>
+          prevPosts.map((post) =>
+            post.id === postId ? { ...post, reactions: result.reactions } : post
+          )
+        );
+      }
 
       if (onReactionSelect) {
         onReactionSelect(reactionType);
@@ -58,8 +73,15 @@ export default function ReactionPicker({
     }
   }
 
+  const alignClass =
+    align === 'start'
+      ? styles.alignStart
+      : align === 'end'
+        ? styles.alignEnd
+        : '';
+
   return (
-    <div className={styles.reactionPicker} ref={pickerRef}>
+    <div className={`${styles.reactionPicker} ${alignClass}`} ref={pickerRef}>
       {REACTIONS.map((reaction) => {
         const hasReacted = currentReactions[reaction.type]?.some(u => u.id === currentUserId);
 

--- a/src/components/ReactionPicker/ReactionPicker.module.scss
+++ b/src/components/ReactionPicker/ReactionPicker.module.scss
@@ -16,10 +16,23 @@
   box-shadow: var(--shadow-lg);
   margin-bottom: $spacing-2;
   z-index: $z-popover;
-  animation: popIn 150ms $ease-out;
+  animation: popInCenter 150ms $ease-out;
 }
 
-@keyframes popIn {
+.alignStart {
+  left: 0;
+  transform: none;
+  animation-name: popInStart;
+}
+
+.alignEnd {
+  left: auto;
+  right: 0;
+  transform: none;
+  animation-name: popInEnd;
+}
+
+@keyframes popInCenter {
   from {
     opacity: 0;
     transform: translateX(-50%) scale(0.9) translateY(8px);
@@ -27,6 +40,28 @@
   to {
     opacity: 1;
     transform: translateX(-50%) scale(1) translateY(0);
+  }
+}
+
+@keyframes popInStart {
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes popInEnd {
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
   }
 }
 


### PR DESCRIPTION
## JIRA Ticket Link

https://atriadev.atlassian.net/browse/AFR-206

## Summary (a few sentences describing what this PR is doing)

Added reaction option to private messages. Also moved option button to be apart of a new hover box. Hover box appears when hovering over messages.

Everything still works E2E (tested locally)

<img width="223" height="155" alt="image" src="https://github.com/user-attachments/assets/45e4db7b-00c2-48b6-8c94-6ccec17dcdd7" />

<img width="362" height="137" alt="image" src="https://github.com/user-attachments/assets/de3c67d2-edcc-4a5c-a95a-fd3f59246a17" />

<img width="344" height="380" alt="image" src="https://github.com/user-attachments/assets/34efb99e-4c90-4ad9-aac8-64b19088c8f8" />

## Extra Notes

I do think with the current design. The option button design might need to be updated in the future. Right now it locks the whole screen but it would look better if it appeared similar to how reactions are shown. Also when editing text, it might be more natural for it to appear within the actual text bubble (instead of a popup in the centre of the screen).
