### PR TITLE
fix(post): add multi-image upload support and delete-image function

### DIFF
--- a/src/api/post.js
+++ b/src/api/post.js
@@ -1,11 +1,10 @@
 import { authenticatedFetch } from '@/utils/authHelpers';
 import { BASE_URL } from '@/constants/api';
 
-export async function updatePost(postId, { content, image, pinned, tags = [] }) {
+export async function updatePost(postId, { content, pinned, tags = [] }) {
 	const formData = new FormData();
 
 	if (content !== undefined) formData.append("content", content);
-	if (image !== undefined && image !== null) formData.append("image", image);
 	if (pinned !== undefined) formData.append("pinned", pinned);
 
 	tags.forEach((tag) => {
@@ -28,7 +27,7 @@ export async function updatePost(postId, { content, image, pinned, tags = [] }) 
 export async function createPost({ content, images = [], pinned, tags = [], anonymous }) {
 	const formData = new FormData();
 	formData.append("content", content)
-	images.forEach((img) => formData.append("image", img));
+	images.forEach((img) => formData.append("images", img));
 	if (pinned) { formData.append("pinned", pinned) };
 	if (anonymous) { formData.append("anonymous", anonymous); }
 
@@ -44,6 +43,36 @@ export async function createPost({ content, images = [], pinned, tags = [], anon
 	if (!response.ok) {
 		const errorText = await response.text();
 		throw new Error(`Failed to create post: ${errorText}`);
+	}
+
+	return await response.json();
+}
+
+export async function addPostImages(postId, images) {
+	const formData = new FormData();
+	images.forEach((img) => formData.append("images", img));
+
+	const response = await authenticatedFetch(`${BASE_URL}/post/${postId}/images/`, {
+		method: "POST",
+		body: formData,
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Failed to add images: ${errorText}`);
+	}
+
+	return await response.json();
+}
+
+export async function deletePostImage(postId, imageId) {
+	const response = await authenticatedFetch(`${BASE_URL}/post/${postId}/images/${imageId}/`, {
+		method: "DELETE",
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Failed to delete image: ${errorText}`);
 	}
 
 	return await response.json();

--- a/src/components/Post/Post.jsx
+++ b/src/components/Post/Post.jsx
@@ -8,18 +8,20 @@ import Tag from "@/components/Tag/Tag";
 import { getCookie } from "@/utils/authHelpers";
 import InlineComments from "@/components/InlineComments/InlineComments";
 import ReactionPicker from "../ReactionPicker/ReactionPicker";
-import { updatePost } from "@/api/post";
+import { updatePost, addPostImages, deletePostImage } from "@/api/post";
 import { authenticatedFetch } from "@/utils/authHelpers";
 import Icon from "@/icons/Icon";
 import { getReactionEmoji } from "@/constants/reactions";
 import { BASE_URL } from "@/constants/api";
+
+const MAX_IMAGES = 10;
 
 export default function Post({
   fullName,
   organization,
   date,
   content,
-  postImage,
+  postImages = [],
   links,
   comments,
   userId,
@@ -41,8 +43,10 @@ export default function Post({
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   const [editText, setEditText] = useState(content.join("\n"));
-  const [editImage, setEditImage] = useState(null);
+  const [keptImages, setKeptImages] = useState([]);
+  const [newImages, setNewImages] = useState([]);
   const [showComments, setShowComments] = useState(false);
   const [reportResponse, setReportResponse] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -55,30 +59,41 @@ export default function Post({
   const hideAuthorDetails = anonymous && !isMyOwnPost;
   // UPDATE POST
   async function handleUpdatePost() {
+    setIsUpdating(true);
     try {
-      const result = await updatePost(postId, {
-        content: editText,
-        image: editImage,
-        tags: editTags,
-      });
-      console.log("Post updated successfully:", result);
+      // updatePost only deal with text edits, not image edits (due to backend setting)
+      await updatePost(postId, { content: editText, tags: editTags });
+
+      // delete images
+      const keptIds = new Set(keptImages.map((img) => img.id));
+      const removedIds = postImages
+        .map((img) => img.id)
+        .filter((id) => !keptIds.has(id));
+
+      await Promise.all(removedIds.map((id) => deletePostImage(postId, id)));
+
+      // add images
+      let addedImages = [];
+      if (newImages.length > 0) {
+        const result = await addPostImages(postId, newImages);
+        addedImages = result.images || [];
+      }
+
+      const finalImages = [...keptImages, ...addedImages];
 
       setPosts((prevPosts) =>
-        prevPosts.map((post) =>
-          post.id === postId
-            ? {
-                ...post,
-                content: [editText],
-                tags: editTags,
-                postImage: result.post?.image || post.postImage, // updated image
-              }
-            : post,
+        prevPosts.map((prevPost) =>
+          prevPost.id === postId
+            ? { ...prevPost, content: [editText], tags: editTags, postImages: finalImages }
+            : prevPost,
         ),
       );
 
       setShowEditModal(false);
     } catch (error) {
       console.error("Error updating post:", error);
+    } finally {
+      setIsUpdating(false);
     }
   }
 
@@ -128,9 +143,14 @@ export default function Post({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [showOptions]);
 
-  function isValidImage(img) {
-    return img && img !== "null" && img !== "";
-  }
+
+  // Reset image state each time the edit modal opens so stale edits don't persist across sessions.
+  useEffect(() => {
+    if (showEditModal) {
+      setKeptImages([...postImages]);
+      setNewImages([]);
+    }
+  }, [showEditModal]);
 
   // REPORT POST
   const handleReportPost = async () => {
@@ -256,24 +276,41 @@ export default function Post({
                   onChange={(e) => setEditText(e.target.value)}
                 />
 
-                {/* Image preview */}
-                {(editImage || isValidImage(postImage)) && (
-                  <div className={styles.editImagePreview}>
-                    <img
-                      src={
-                        editImage ? URL.createObjectURL(editImage) : postImage
-                      }
-                      alt="Preview"
-                      className={styles.editPreviewImg}
-                    />
-                    <button
-                      className={styles.editRemoveImage}
-                      onClick={() => setEditImage(null)}
-                      aria-label="Remove image"
-                    >
-                      <Icon name="close" size={14} />
-                    </button>
+                {/* Imge Preview in the Edit Post Modal */}
+                {/* keptImages: already saved in the database. newImages: selected locally in this session, not yet uploaded. */}
+                {(keptImages.length > 0 || newImages.length > 0) && (
+                  <div className={styles.editImageGrid}>
+                    {keptImages.map((img) => (
+                      <div key={img.id} className={styles.editImagePreview}>
+                        <img src={img.url} alt="Preview" className={styles.editPreviewImg} />
+                        <button
+                          className={styles.editRemoveImage}
+                          onClick={() => setKeptImages((prev) => prev.filter((e) => e.id !== img.id))}
+                          aria-label="Remove image"
+                        >
+                          <Icon name="close" size={14} />
+                        </button>
+                      </div>
+                    ))}
+                    {newImages.map((file, idx) => (
+                      <div key={`new-${idx}`} className={styles.editImagePreview}>
+                        <img src={URL.createObjectURL(file)} alt="New preview" className={styles.editPreviewImg} />
+                        <button
+                          className={styles.editRemoveImage}
+                          onClick={() => setNewImages((prev) => prev.filter((_, i) => i !== idx))}
+                          aria-label="Remove image"
+                        >
+                          <Icon name="close" size={14} />
+                        </button>
+                      </div>
+                    ))}
                   </div>
+                )}
+
+                {keptImages.length + newImages.length >= MAX_IMAGES && (
+                  <p className={styles.editImageWarning}>
+                    You can upload a maximum of {MAX_IMAGES} images per post.
+                  </p>
                 )}
 
                 {/* Tags */}
@@ -295,6 +332,7 @@ export default function Post({
                       document.getElementById(`editImg-${postId}`).click()
                     }
                     aria-label="Add image"
+                    disabled={keptImages.length + newImages.length >= MAX_IMAGES}
                   >
                     <Icon name="image" size={20} />
                   </button>
@@ -303,11 +341,18 @@ export default function Post({
                     accept="image/*"
                     id={`editImg-${postId}`}
                     hidden
+                    multiple
                     onChange={(e) => {
-                      const file = e.target.files[0];
-                      if (file && file.type.startsWith("image/")) {
-                        setEditImage(file);
+                      const files = Array.from(e.target.files).filter((f) =>
+                        f.type.startsWith("image/")
+                      );
+                      if (files.length) {
+                        setNewImages((prev) => {
+                          const remaining = MAX_IMAGES - keptImages.length - prev.length;
+                          return [...prev, ...files.slice(0, remaining)];
+                        });
                       }
+                      e.target.value = "";
                     }}
                   />
                 </div>
@@ -316,8 +361,9 @@ export default function Post({
                   <button
                     className={styles.updateButton}
                     onClick={handleUpdatePost}
+                    disabled={isUpdating}
                   >
-                    Update
+                    {isUpdating ? "Updating..." : "Update"}
                   </button>
                 </div>
               </div>
@@ -448,12 +494,17 @@ export default function Post({
             {link.text}
           </a>
         ))}
-        {isValidImage(postImage) && (
-          <img
-            src={postImage}
-            alt="Post content"
-            className={styles.postImage}
-          />
+        {postImages.length > 0 && (
+          <div className={styles.postImagesGrid}>
+            {postImages.map((img) => (
+              <img
+                key={img.id}
+                src={img.url}
+                alt="Post content"
+                className={styles.postImage}
+              />
+            ))}
+          </div>
         )}
       </div>
 

--- a/src/components/Post/Post.module.scss
+++ b/src/components/Post/Post.module.scss
@@ -427,6 +427,13 @@
   }
 }
 
+.editImageGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-4;
+  margin-top: $spacing-2;
+}
+
 .editImagePreview {
   position: relative;
   display: inline-block;
@@ -475,6 +482,11 @@
   @include caption;
 }
 
+.editImageWarning {
+  color: $error-500;
+  @include caption;
+}
+
 .editModalFooter {
   display: flex;
   flex-direction: column;
@@ -512,6 +524,11 @@
   &:hover {
     background-color: var(--bg-hover);
     color: var(--icon-hover);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 }
 
@@ -564,6 +581,11 @@
   @include button-primary;
   @include button-md;
   min-width: 100px;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 }
 
 .cancelButton {

--- a/src/components/PostModal/PostModal.jsx
+++ b/src/components/PostModal/PostModal.jsx
@@ -18,13 +18,13 @@ export default function Modal({
 }) {
   const [text, setText] = useState('');
   const [pinned, setPinned] = useState(false);
-  const [image, setImage] = useState(null);
   const [error, setError] = useState('');
   const [images, setImages] = useState([]);
   const [tag, setTag] = useState("");
   const [tags, setTags] = useState([]);
   const [tagErrorText, setTagErrorText] = useState("");
   const MAX_POST_LEN = 1000;
+  const MAX_IMAGES = 10;
 
   const postImageRef = useRef(null);
 
@@ -33,7 +33,10 @@ export default function Modal({
     const validImages = files.filter(file => file.type.startsWith("image/"));
 
     if (validImages.length) {
-      setImages(prev => [...prev, ...validImages]);
+      setImages(prev => {
+        const remaining = MAX_IMAGES - prev.length;
+        return [...prev, ...validImages.slice(0, remaining)];
+      });
     } else {
       alert("Please upload valid image files.");
     }
@@ -62,7 +65,7 @@ export default function Modal({
         created_at: data.post.created_at,
         date: formatDistance(new Date(data.post.created_at), new Date(), { addSuffix: true }),
         content: [data.post.content],
-        postImage: data.post.image,
+        postImages: data.post.images || [],
         pinned: data.post.pinned || false,
         tags: data.post.tags || [],
         links: [],
@@ -82,7 +85,6 @@ export default function Modal({
       });
 
       setText('');
-      setImage(null);
       setImages([]);
       setTags([]);
       setTag('');
@@ -140,6 +142,10 @@ export default function Modal({
             </div>
           )}
 
+          {images.length >= MAX_IMAGES && (
+            <p className={styles.errorMessage}>You can upload a maximum of {MAX_IMAGES} images per post.</p>
+          )}
+
           {error && <p className={styles.errorMessage}>{error}</p>}
 
           <TagCreationField
@@ -159,6 +165,7 @@ export default function Modal({
               className={styles.iconButton}
               onClick={() => postImageRef.current.click()}
               aria-label="Add image"
+              disabled={images.length >= MAX_IMAGES}
             >
               <Icon name="image" size={20} />
             </button>

--- a/src/components/PostModal/PostModal.module.scss
+++ b/src/components/PostModal/PostModal.module.scss
@@ -193,6 +193,11 @@
     background-color: var(--bg-hover);
     color: var(--icon-hover);
   }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
 }
 
 .pinned {

--- a/src/pages/NewsfeedPage/NewsfeedPage.module.scss
+++ b/src/pages/NewsfeedPage/NewsfeedPage.module.scss
@@ -86,13 +86,17 @@
   display: flex;
   gap: $spacing-3;
   overflow-x: auto;
-  padding: 0 $spacing-1 $spacing-2;
+  padding: $spacing-2 $spacing-1 $spacing-2;
   @include custom-scrollbar;
 }
 
 .imagePreviewContainer {
   position: relative;
   flex-shrink: 0;
+
+  &:last-child {
+    margin-right: $spacing-1;
+  }
 }
 
 .previewImage {
@@ -171,6 +175,11 @@
   &:hover {
     background-color: var(--bg-hover);
     color: var(--icon-hover);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 }
 

--- a/src/pages/NewsfeedPage/index.jsx
+++ b/src/pages/NewsfeedPage/index.jsx
@@ -20,6 +20,7 @@ import PrivacyModal from '@/components/PrivacyModal/PrivacyModal';
 
 const POSTS_PER_PAGE = 10;
 const MAX_POST_LEN = 1000;
+const MAX_IMAGES = 10;
 
 export default function NewsfeedPage() {
   const router = useRouter();
@@ -149,7 +150,7 @@ export default function NewsfeedPage() {
             date: formatDistance(new Date(p.created_at), new Date(), { addSuffix: true }),
             created_at: p.created_at,
             content: [p.content],
-            postImage: p.image || null,
+            postImages: p.images || [],
             links: [],
             comments: p.comments || [],
             reactions: p.reactions || {},
@@ -192,7 +193,10 @@ export default function NewsfeedPage() {
     const files = Array.from(e.target.files);
     const validImages = files.filter(file => file.type.startsWith("image/"));
     if (validImages.length) {
-      setPostImages(prev => [...prev, ...validImages]);
+      setPostImages(prev => {
+        const remaining = MAX_IMAGES - prev.length;
+        return [...prev, ...validImages.slice(0, remaining)];
+      });
     }
     e.target.value = "";
   };
@@ -219,7 +223,7 @@ export default function NewsfeedPage() {
         created_at: data.post.created_at,
         date: formatDistance(new Date(data.post.created_at), new Date(), { addSuffix: true }),
         content: [data.post.content],
-        postImage: data.post.image,
+        postImages: data.post.images || [],
         tags: data.post.tags || [],
         links: [],
         comments: data.post.comments || [],
@@ -346,6 +350,10 @@ export default function NewsfeedPage() {
             </div>
           )}
 
+          {postImages.length >= MAX_IMAGES && (
+            <p className={styles.postErrorMessage}>You can upload a maximum of {MAX_IMAGES} images per post.</p>
+          )}
+
           {postError && <p className={styles.postErrorMessage}>{postError}</p>}
 
           {/* Tags — only shown when composing */}
@@ -368,6 +376,7 @@ export default function NewsfeedPage() {
                 className={styles.toolbarButton}
                 onClick={() => postImageRef.current.click()}
                 aria-label="Add image"
+                disabled={postImages.length >= MAX_IMAGES}
               >
                 <Icon name="image" size={20} />
               </button>
@@ -458,7 +467,7 @@ export default function NewsfeedPage() {
                 organization={post.organization}
                 date={post.date}
                 content={post.content}
-                postImage={post.postImage}
+                postImages={post.postImages}
                 links={post.links}
                 comments={post.comments}
                 reactions={post.reactions}


### PR DESCRIPTION
I implemented both frontend and backend. This is the PR for the frontend part, and the corresponding backend parts have already been merged.

**JIRA Ticket Link**
https://anselatria2.atlassian.net/browse/KAN-60?atlOrigin=eyJpIjoiMjk2MGFhNTNmMmZmNDFlODk0YTZiZWRlYjQxNzU5NmMiLCJwIjoiaiJ9

**Migrations Required?**
YES ✅

**Summary (a few sentences describing what this PR is doing)**
- Replace single image field with multi-image support in Post, NewsfeedPage
- Add addPostImages() and deletePostImage() API functions
- Fix createPost() to use the correct multipart key ("images", not "image")
- Remove image param from updatePost() — images now managed via dedicated endpoints, and updatePost() only deal with the text changes
- Add 10-image limit per post(a new limit set for this PR), with warning text and disabled button across all upload UIs

Now, a user is able to upload multiple images per post and delete any of them.

I upload the same screen video as the one I used for the backend PR.

https://github.com/user-attachments/assets/ccc017a6-bbfc-4893-8b91-450bf756f090

