### PR TITLE
fix(post): pass postImages prop correctly to Post component

### DIFF
--- a/src/pages/NewsfeedPage/index.jsx
+++ b/src/pages/NewsfeedPage/index.jsx
@@ -469,7 +469,7 @@ export default function NewsfeedPage() {
                 date={post.date}
                 content={post.content}
                 isVerified={post.isVerified}
-                postImage={post.postImage}
+                postImages={post.postImages}
                 links={post.links}
                 comments={post.comments}
                 reactions={post.reactions}


### PR DESCRIPTION
## Summary
- The `Post` component expects a `postImages` array prop, but `NewsfeedPage` was passing a nonexistent `postImage` (singular) prop
- As a result, uploaded images — including multi-image posts — never rendered in the newsfeed
- Fixes the caller in `NewsfeedPage/index.jsx` to pass `postImages={post.postImages}`

## Root cause

This is a bug that was introduced during a merge of the debugging PR "**fix(post): add multi-image upload support and delete-image function"**.

- **2026-06-09** — The original commit on `fix/multi-images-upload` (`ee68b0f`) already had this correct: `postImages={post.postImages}`. This is why the video attached to the PR showed multi-image upload tested fine locally at the time. The code under test was correct.
- **2026-06-20** — `main` was merged into the feature branch (`Merge branch 'main' into fix/multi-images-upload`, `d8b9e6c`). At that point `main` still had the old single-image line (`postImage={post.postImage}`), so this line conflicted between the two branches. The conflict was resolved by incorrectly keeping `main`'s (old) version instead of the feature branch's fix.
- That merge commit was then merged into `main` as ("fix(post): add multi-image upload support (#74)"), shipping the stale line even though the tested code had it right.

In short: the implementation was correct from the start; the regression stemmed from choosing the wrong side when resolving a merge conflict, not from a coding mistake.

https://github.com/user-attachments/assets/0485a9e0-6dc2-4ef7-944b-2762809e6f01
