### PR TITLE
feat: always show create event button and disable when n…

### DIFF
--- a/src/pages/EventsPage/EventsPage.module.scss
+++ b/src/pages/EventsPage/EventsPage.module.scss
@@ -39,6 +39,11 @@
   @include button-primary;
   @include button-sm;
   white-space: nowrap;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 }
 
 .headerControls {

--- a/src/pages/EventsPage/index.jsx
+++ b/src/pages/EventsPage/index.jsx
@@ -490,14 +490,15 @@ export default function EventsPage() {
       <header className={styles.pageHeader}>
         <div className={styles.headerContent}>
           <h1 className={styles.pageTitle}>Events</h1>
-          {isStaff && (
-            <button
-              className={styles.createEventButton}
-              onClick={() => setShowCreateModal(true)}
-            >
-              + Create Event
-            </button>
-          )}
+          <button
+            className={styles.createEventButton}
+            disabled={!isStaff}
+            onClick={() => setShowCreateModal(true)}
+            title={!isStaff ? "You don't have permission to create events" : undefined}
+            aria-label={isStaff ? "Create event" : "Create event - staff only"}
+          >
+            + Create Event
+          </button>
         </div>
         <div className={styles.headerControls}>
           <div className={styles.tabBar} role="tablist" aria-label="Event filter">


### PR DESCRIPTION
Description
This PR implements better UX for the Events page by making the "Create Event" button always visible, but disabled for users without staff permissions.

<img width="1916" height="1196" alt="image" src="https://github.com/user-attachments/assets/c4e9fd8a-9aa7-4593-bf4d-afbefd43bc04" />
